### PR TITLE
remove navigation to hidden posts

### DIFF
--- a/_includes/post-nav.html
+++ b/_includes/post-nav.html
@@ -3,10 +3,32 @@
 -->
 
 <div class="post-navigation d-flex justify-content-between">
-  {% if page.next.url %}
-  <a href="{{ site.baseurl }}{{ page.next.url }}" class="btn btn-outline-primary"
+  {% if page.hidden != true %}
+    {% assign published_posts = site.posts | where_exp: "item", "item.pin != true and item.hidden != true" %}
+  {% else %}
+    {% assign published_posts = site.posts | where_exp: "item", "item.pin != true" %}
+  {% endif %}
+
+  {% for post in published_posts %}
+      {% if post.url == page.url %}
+        {% assign post_index0 = forloop.index0 %}
+        {% assign post_index1 = forloop.index %}
+      {% endif %}
+  {% endfor %}
+
+  {% for post in published_posts %}
+    {% if post_index0 == forloop.index %}
+        {% assign next_post = post %}
+    {% endif %}
+    {% if post_index1 == forloop.index0 %}
+        {% assign prev_post = post %}
+    {% endif %}
+  {% endfor %}
+
+  {% if next_post.url %}
+  <a href="{{ site.baseurl }}{{ next_post.url }}" class="btn btn-outline-primary"
     prompt="{{ site.data.locales[lang].post.button.previous }}">
-    <p>{{ page.next.title }}</p>
+    <p>{{ next_post.title }}</p>
   </a>
   {% else %}
   <div class="btn btn-outline-primary disabled"
@@ -15,10 +37,10 @@
   </div>
   {% endif %}
 
-  {% if page.previous.url %}
-  <a href="{{ site.baseurl }}{{page.previous.url}}" class="btn btn-outline-primary"
+  {% if prev_post.url %}
+  <a href="{{ site.baseurl }}{{prev_post.url}}" class="btn btn-outline-primary"
     prompt="{{ site.data.locales[lang].post.button.next }}">
-    <p>{{ page.previous.title }}</p>
+    <p>{{ prev_post.title }}</p>
   </a>
   {% else %}
   <div class="btn btn-outline-primary disabled"


### PR DESCRIPTION
this PR updates the navigation to remove links/references to hidden posts.

to hide a post just add `hidden: true` to the front matter of the post, e.g.,

```md
---
title: 'Chapter 1 Part 2 - Commentary - Introduction to Quantum Computing'
math: true
hidden: true
---

Ours is a world governed by classical physics, in which a film is either playing or paused, a coin lands on either heads or tails, and a cat is either alive or dead. Classical physics is what we experience in our everyday lives.

```

this would hide the chapter 1, part 2 post from any of the navigation. however, the post would still be accessible using the post's URL (which is based on the title of the post's markdown file minus the date & extension). for example,  this file

```
2022-06-14-CHAPTER-1-Part-2-Introduction-to-Quantum-Computing.md
```

would be accessible at this URL:

```
https://quantum-kittens.github.io/posts/CHAPTER-1-Part-2-Introduction-to-Quantum-Computing
```

